### PR TITLE
[Fixes] Various fixes to recrafts and date sorting

### DIFF
--- a/CraftersRecieptBook.lua
+++ b/CraftersRecieptBook.lua
@@ -166,17 +166,20 @@ local function GetProfessionCrafts()
 
 		local orderType = data.orderInfo.orderType
 		if data.profession == profession1 then
-			profession1Crafts = profession1Crafts + 1
-			profession1Profit = profession1Profit + data.orderInfo.tipAmount - data.orderInfo.consortiumCut
-			profession1Data[orderType + 1] = profession1Data[orderType + 1] + 1
+			if not data.orderInfo.isFulfillable then
+				profession1Crafts = profession1Crafts + 1
+				profession1Profit = profession1Profit + data.orderInfo.tipAmount - data.orderInfo.consortiumCut
+				profession1Data[orderType + 1] = profession1Data[orderType + 1] + 1
+			end
 		elseif data.profession ~= profession1 then
 			if not profession2 then
 				profession2 = data.profession
 	 		end
-
-			profession2Crafts = profession2Crafts + 1
-			profession2Profit = profession2Profit + data.orderInfo.tipAmount - data.orderInfo.consortiumCut
-			profession2Data[orderType + 1] = profession2Data[orderType + 1] + 1
+			if not data.orderInfo.isFulfillable then
+				profession2Crafts = profession2Crafts + 1
+				profession2Profit = profession2Profit + data.orderInfo.tipAmount - data.orderInfo.consortiumCut
+				profession2Data[orderType + 1] = profession2Data[orderType + 1] + 1
+			end
 		end
 	end
 
@@ -311,29 +314,33 @@ function addon:UpdateTotals()
 	local profession1, profession2
 	local profession1Profit = 0
 	local profession2Profit = 0
+	local properCount = 0
 	if not profession.profession then return end
 
 	local remainingClaims = C_CraftingOrders.GetOrderClaimInfo(profession.profession).claimsRemaining or 0
 	for id, data in ipairs(addon.db.char.orders) do
-		local orderprofit = data.orderInfo.tipAmount - data.orderInfo.consortiumCut 
-		totalProfit = totalProfit + orderprofit
-
-		if data.date.month == currentDate.month and data.date.day == currentDate.day and data.date.year == currentDate.year then
+		if not data.orderInfo.isFulfillable then
+			properCount = properCount + 1
 			local orderprofit = data.orderInfo.tipAmount - data.orderInfo.consortiumCut 
-			dailyProfit = dailyProfit + orderprofit
-		end
+			totalProfit = totalProfit + orderprofit
 
-		if data.results then 
-			if data.results.isCrit then
-				inspired = inspired + 1
+			if data.date.month == currentDate.month and data.date.day == currentDate.day and data.date.year == currentDate.year then
+				local orderprofit = data.orderInfo.tipAmount - data.orderInfo.consortiumCut 
+				dailyProfit = dailyProfit + orderprofit
 			end
 
-			if data.results.resourcesReturned then
-				resourceful = resourceful + 1
-			end
+			if data.results then
+				if data.results.isCrit then
+					inspired = inspired + 1
+				end
 
-			if data.results.multicraft ~= 0 then
-				multicraft = multicraft + 1
+				if data.results.resourcesReturned then
+					resourceful = resourceful + 1
+				end
+
+				if data.results.multicraft ~= 0 then
+					multicraft = multicraft + 1
+				end
 			end
 		end
 	end
@@ -351,7 +358,7 @@ function addon:UpdateTotals()
 
 	local profession1 = addon:GetProfessionName(craftData[1])
 	local profession2
-	addon.detailsTextFrame.Field1:SetText("Total Orders Crafted: "..#addon.db.char.orders)
+	addon.detailsTextFrame.Field1:SetText("Total Orders Crafted: "..properCount)
 	addon.detailsTextFrame.Field2:SetText(profession1..": "..craftData[2])
 
 	if craftData[5] then
@@ -370,6 +377,6 @@ function addon:UpdateTotals()
 	addon.detailsTextFrame2.Field3:SetText("Multicraft Procs: "..multicraft)
 
 	local profit = addon:ConvertToGold(craftData[3])
-	addon.detailsTextFrame3.Field1:SetText("=Profit by Profession=")
+	addon.detailsTextFrame3.Field1:SetText("Profit by Profession")
 	addon.detailsTextFrame3.Field2:SetText(profession1..": ".. profit[1].."   "..profit[2].."   "..profit[3])	 
 end

--- a/Modules/OrderList.lua
+++ b/Modules/OrderList.lua
@@ -472,13 +472,13 @@ function RecieptTableCellDateMixin:Populate(rowData, dataIndex)
 
 	zone = "am"
 	hour = orderdate.hour
-	if (hour >= 12) then
+	if (hour > 11) then
 		zone = "pm"
 	end
+
 	hour = hour % 12
 	if (hour == 0) then
 		hour = 12
-		zone = "am"
 	end
 
 	minute = orderdate.min

--- a/Modules/OrderList.lua
+++ b/Modules/OrderList.lua
@@ -32,13 +32,13 @@ local PTC = {
   	RightCellPadding=0,
 	Padding=10,
 	LeftCellPadding=0,
-	Width=220
+	Width=180
   },
   CustomerName={
 	RightCellPadding=0,
 	Padding=10,
 	LeftCellPadding=0,
-	Width=175
+	Width=155
   },
   NoPadding=0,
   StandardPadding=10,
@@ -53,26 +53,25 @@ local PTC = {
 	RightCellPadding=0,
 	Padding=10,
 	LeftCellPadding=0,
-	Width=300
+	Width=280
   },
    Date={
 	RightCellPadding=0,
 	Padding=10,
 	LeftCellPadding=0,
-	Width=75
+	Width=140
   },
-
-	Profession={
+  Profession={
 	RightCellPadding=0,
 	Padding=10,
 	LeftCellPadding=0,
-	Width=85
+	Width=110
   },
   Type={
 	RightCellPadding=0,
 	Padding=10,
 	LeftCellPadding=0,
-	Width=65
+	Width=70
   }
 }
 
@@ -207,7 +206,7 @@ function ProfessionsCraftingOrderPageMixin2:SortOrderIsValid(sortOrder)
 end
 
 
-function date_to_excel_date(dd, mm, yy) 
+function date_to_excel_date(ss, min, hh, dd, mm, yy) 
 local days, monthdays, leapyears, nonleapyears, nonnonleapyears
 
     monthdays= { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
@@ -228,19 +227,20 @@ local days, monthdays, leapyears, nonleapyears, nonnonleapyears
     c=c+1
     end
 
-    days=days+dd+1
+    days = days + dd + 1
+	daysInMinutes = days * 24 * 60
+	minutes = (hh * 60) + min
+	seconds = ((daysInMinutes + minutes) * 60) + ss
 
-    return days
+    return seconds
 end
 
 local function SortDate(lhs, rhs)
-
-
 	if not lhs or not rhs then return false end
 
-	return date_to_excel_date(lhs.date.day, lhs.date.month, lhs.date.year) > date_to_excel_date(rhs.date.day, rhs.date.month, rhs.date.year)
-
-
+	a = date_to_excel_date(lhs.date.sec, lhs.date.min, lhs.date.hour, lhs.date.day, lhs.date.month, lhs.date.year)
+	b = date_to_excel_date(rhs.date.sec, rhs.date.min, rhs.date.hour, rhs.date.day, rhs.date.month, rhs.date.year)
+	return a > b
 end
 
 local function ApplySortOrder(sortOrder, lhs, rhs)
@@ -261,7 +261,14 @@ local function ApplySortOrder(sortOrder, lhs, rhs)
 	elseif sortOrder == "TYPE" then
 		return lhs.orderInfo.orderType > rhs.orderInfo.orderType, lhs.orderInfo.orderType == rhs.orderInfo.orderType;
 	else --if sortOrder == "Date" then
-		return SortDate(lhs, rhs), (lhs.date.year == rhs.date.year and lhs.date.month == rhs.date.month and lhs.date.day == rhs.date.day)
+		return SortDate(lhs, rhs), (
+			lhs.date.sec == rhs.date.sec and 
+			lhs.date.min == rhs.date.min and 
+			lhs.date.hour == rhs.date.hour and 
+			lhs.date.year == rhs.date.year and
+			lhs.date.month == rhs.date.month and 
+			lhs.date.day == rhs.date.day
+		)
 	end
 
 	--return false, false;
@@ -462,7 +469,24 @@ end
 RecieptTableCellDateMixin = CreateFromMixins(TableBuilderCellMixin);
 function RecieptTableCellDateMixin:Populate(rowData, dataIndex)
 	local orderdate = rowData.option.date
-	local text = orderdate.month.."/"..orderdate.day.."/"..orderdate.year
+
+	zone = "am"
+	hour = orderdate.hour
+	if (hour >= 12) then
+		zone = "pm"
+	end
+	hour = hour % 12
+	if (hour == 0) then
+		hour = 12
+		zone = "am"
+	end
+
+	minute = orderdate.min
+	if (minute < 10) then
+		minute = "0"..minute
+	end
+
+	local text = "  "..orderdate.month.."/"..orderdate.day.."/"..orderdate.year.." "..hour..":"..minute.." "..zone
 
 	ProfessionsTableCellTextMixin.SetText(self, text);
 end
@@ -516,6 +540,9 @@ function RecieptTableCellActualCommissionMixin:Populate(rowData, dataIndex)
 
 	--TODO: hide values of 0
 	local text = profit[1].."   "..profit[2].."   "..profit[3]
+	if rowData.option.orderInfo.isFulfillable then
+		text = "--- recraft ---";
+	end
 	ProfessionsTableCellTextMixin.SetText(self, text);
 end
 
@@ -562,6 +589,10 @@ function RecieptTableCellProcsMixin:Populate(rowData, dataIndex)
 			local ItemID = Item:CreateFromItemID(d.itemID);
 			local ItemName = ItemID:GetItemName();
 			local quantity = d.quantity
+
+			if (ItemName == nil) then
+				ItemName = ''
+			end
 
 			text = text..ItemName.."("..quantity..")"
 		end


### PR DESCRIPTION
## Changes

* Time shown as `01/01/2023 12:00am`
* Time sort is second accurate to reflect multiple recrafts on the same order in a short timespan
* Recrafts are shown as `--recraft--`
* Recrafts on the same order do not count towards total crafts
* Recrafts on the same order do not overcount profit